### PR TITLE
fix: ensure ftruncate writes envelope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ gocryptfs.1
 
 # Source tarball version. Should never be committed to git.
 /VERSION
+
+# Various developer/debugging excludes
+.vscode
+gocryptfs-xray
+__debug_bin*

--- a/internal/fusefrontend/file.go
+++ b/internal/fusefrontend/file.go
@@ -300,7 +300,6 @@ func (f *File) doWrite(data []byte, off int64) (uint32, syscall.Errno) {
 	//
 	// If the file ID is not cached, read it from disk
 	var err error
-	var key []byte
 	if f.fileTableEntry.ID == nil {
 		var err error
 		fileID, err := f.readFileID()
@@ -315,47 +314,10 @@ func (f *File) doWrite(data []byte, off int64) (uint32, syscall.Errno) {
 
 			//set up the envelope key if needed
 			if f.rootNode.args.Envelope {
-				var envKeyID string
-				var wrapper []byte
-				//create the wrapped key
-				envKeyID = tkc.Get().GetCurrentKeyID()
-				iKey := cryptocore.RetrieveKey(envKeyID, true)
-				envKey, ok := iKey.(kem.Kem)
-				if !ok {
-					tlog.Warn.Printf("doWrite %d: somehow got wrong type for envelope key", f.qIno.Ino)
-					return 0, syscall.EIO
-				}
-				//TODO: Add a way to add this to the decrypted cache so we dont have to encrypt and immediately decrypt this
-				key, wrapper, err = envKey.Wrap()
+				err = f.initializeEnvelopeKey()
 				if err != nil {
-					tlog.Warn.Printf("doWrite %d: Could not create wrapped key for file, err: %v", f.qIno.Ino, err)
 					return 0, syscall.EIO
 				}
-				crypto.Zeroize(key)
-
-				isDarwin := strings.EqualFold(build.Default.GOOS, "darwin")
-				// save the wrapped key
-				if isDarwin {
-					err = unix.Fsetxattr(int(f.fd.Fd()), tkc.EnvelopeIDAttrName, []byte(envKeyID), 0)
-				} else {
-					err = xattr.FSet(f.fd, tkc.EnvelopeIDAttrName, []byte(envKeyID))
-				}
-				if err != nil {
-					tlog.Warn.Printf("doWrite %d: error setting envelopeID: %v", f.qIno.Ino, err)
-					return 0, syscall.EIO
-				}
-
-				if isDarwin {
-					err = unix.Fsetxattr(int(f.fd.Fd()), tkc.WrappedKeyAttrName, wrapper, 0)
-				} else {
-					err = xattr.FSet(f.fd, tkc.WrappedKeyAttrName, wrapper)
-				}
-				if err != nil {
-					tlog.Warn.Printf("doWrite %d: error setting wrappedKey: %v", f.qIno.Ino, err)
-					return 0, syscall.EIO
-				}
-				f.fileTableEntry.EnvKeyID = envKeyID
-				f.fileTableEntry.Wrapper = wrapper
 			}
 
 		} else if err != nil {
@@ -438,6 +400,52 @@ func (f *File) doWrite(data []byte, off int64) (uint32, syscall.Errno) {
 		return 0, fs.ToErrno(err)
 	}
 	return uint32(len(data)), 0
+}
+
+func (f *File) initializeEnvelopeKey() (err error) {
+	var envKeyID string
+	var wrapper []byte
+	var key []byte
+	//create the wrapped key
+	envKeyID = tkc.Get().GetCurrentKeyID()
+	iKey := cryptocore.RetrieveKey(envKeyID, true)
+	envKey, ok := iKey.(kem.Kem)
+	if !ok {
+		tlog.Warn.Printf("doWrite %d: somehow got wrong type for envelope key", f.qIno.Ino)
+		return fmt.Errorf("doWrite %d: somehow got wrong type for envelope key", f.qIno.Ino)
+	}
+	//TODO: Add a way to add this to the decrypted cache so we dont have to encrypt and immediately decrypt this
+	key, wrapper, err = envKey.Wrap()
+	if err != nil {
+		tlog.Warn.Printf("doWrite %d: Could not create wrapped key for file, err: %v", f.qIno.Ino, err)
+		return
+	}
+	crypto.Zeroize(key)
+
+	isDarwin := strings.EqualFold(build.Default.GOOS, "darwin")
+	// save the wrapped key
+	if isDarwin {
+		err = unix.Fsetxattr(int(f.fd.Fd()), tkc.EnvelopeIDAttrName, []byte(envKeyID), 0)
+	} else {
+		err = xattr.FSet(f.fd, tkc.EnvelopeIDAttrName, []byte(envKeyID))
+	}
+	if err != nil {
+		tlog.Warn.Printf("doWrite %d: error setting envelopeID: %v", f.qIno.Ino, err)
+		return fmt.Errorf("doWrite %d: error setting envelopeID: %v", f.qIno.Ino, err)
+	}
+
+	if isDarwin {
+		err = unix.Fsetxattr(int(f.fd.Fd()), tkc.WrappedKeyAttrName, wrapper, 0)
+	} else {
+		err = xattr.FSet(f.fd, tkc.WrappedKeyAttrName, wrapper)
+	}
+	if err != nil {
+		tlog.Warn.Printf("doWrite %d: error setting wrappedKey: %v", f.qIno.Ino, err)
+		return fmt.Errorf("doWrite %d: error setting wrappedKey: %v", f.qIno.Ino, err)
+	}
+	f.fileTableEntry.EnvKeyID = envKeyID
+	f.fileTableEntry.Wrapper = wrapper
+	return
 }
 
 // isConsecutiveWrite returns true if the current write

--- a/internal/fusefrontend/file.go
+++ b/internal/fusefrontend/file.go
@@ -316,6 +316,7 @@ func (f *File) doWrite(data []byte, off int64) (uint32, syscall.Errno) {
 			if f.rootNode.args.Envelope {
 				err = f.initializeEnvelopeKey()
 				if err != nil {
+					tlog.Warn.Printf("doWrite initializeEnvelopeKey returned error: %v", err)
 					return 0, syscall.EIO
 				}
 			}
@@ -411,13 +412,11 @@ func (f *File) initializeEnvelopeKey() (err error) {
 	iKey := cryptocore.RetrieveKey(envKeyID, true)
 	envKey, ok := iKey.(kem.Kem)
 	if !ok {
-		tlog.Warn.Printf("doWrite %d: somehow got wrong type for envelope key", f.qIno.Ino)
-		return fmt.Errorf("doWrite %d: somehow got wrong type for envelope key", f.qIno.Ino)
+		return fmt.Errorf("initializeEnvelopeKey %d: somehow got wrong type for envelope key", f.qIno.Ino)
 	}
 	//TODO: Add a way to add this to the decrypted cache so we dont have to encrypt and immediately decrypt this
 	key, wrapper, err = envKey.Wrap()
 	if err != nil {
-		tlog.Warn.Printf("doWrite %d: Could not create wrapped key for file, err: %v", f.qIno.Ino, err)
 		return
 	}
 	crypto.Zeroize(key)
@@ -430,8 +429,7 @@ func (f *File) initializeEnvelopeKey() (err error) {
 		err = xattr.FSet(f.fd, tkc.EnvelopeIDAttrName, []byte(envKeyID))
 	}
 	if err != nil {
-		tlog.Warn.Printf("doWrite %d: error setting envelopeID: %v", f.qIno.Ino, err)
-		return fmt.Errorf("doWrite %d: error setting envelopeID: %v", f.qIno.Ino, err)
+		return fmt.Errorf("initializeEnvelopeKey %d: error setting envelopeID: %v", f.qIno.Ino, err)
 	}
 
 	if isDarwin {
@@ -440,8 +438,7 @@ func (f *File) initializeEnvelopeKey() (err error) {
 		err = xattr.FSet(f.fd, tkc.WrappedKeyAttrName, wrapper)
 	}
 	if err != nil {
-		tlog.Warn.Printf("doWrite %d: error setting wrappedKey: %v", f.qIno.Ino, err)
-		return fmt.Errorf("doWrite %d: error setting wrappedKey: %v", f.qIno.Ino, err)
+		return fmt.Errorf("initializeEnvelopeKey %d: error setting wrappedKey: %v", f.qIno.Ino, err)
 	}
 	f.fileTableEntry.EnvKeyID = envKeyID
 	f.fileTableEntry.Wrapper = wrapper

--- a/internal/fusefrontend/file_allocate_truncate.go
+++ b/internal/fusefrontend/file_allocate_truncate.go
@@ -206,6 +206,7 @@ func (f *File) truncateGrowFile(oldPlainSz uint64, newPlainSz uint64) syscall.Er
 			if f.rootNode.args.Envelope {
 				err = f.initializeEnvelopeKey()
 				if err != nil {
+					tlog.Warn.Printf("Truncate initializeEnvelopeKey returned error: %v", err)
 					return syscall.EIO
 				}
 			}

--- a/internal/fusefrontend/file_allocate_truncate.go
+++ b/internal/fusefrontend/file_allocate_truncate.go
@@ -202,6 +202,13 @@ func (f *File) truncateGrowFile(oldPlainSz uint64, newPlainSz uint64) syscall.Er
 				return fs.ToErrno(err)
 			}
 			f.fileTableEntry.ID = id
+			//set up the envelope key if needed
+			if f.rootNode.args.Envelope {
+				err = f.initializeEnvelopeKey()
+				if err != nil {
+					return syscall.EIO
+				}
+			}
 		}
 		cSz := int64(f.contentEnc.PlainSizeToCipherSize(newPlainSz))
 		err := syscall.Ftruncate(f.intFd(), cSz)


### PR DESCRIPTION
Here's an attempt at a fix but I very strongly would love a thorough review and maybe some suggestions for other tests to run.

Extracted the creation of the envelope and wrapper header xattrs into a `File` method (`initializeEnvelopeKey`) and call it from both `doWrite` and `truncateGrowFile`.